### PR TITLE
Add Ontario Meta covid-19 collection

### DIFF
--- a/app.js
+++ b/app.js
@@ -14,9 +14,17 @@ app.use(bodyParser.json());
 const cors = require("cors")
 app.use(cors());
 
+app.get("", (req,res) =>{
+  res.send("Please use either /PublicHealthUnit, or /OntarioMetaCovidCase endpoints")
+})
+
+
 //import routes and assign
 const PublicHealthUnit = require('./src/routes/PublicHealthUnit')
 app.use("/PublicHealthUnit", PublicHealthUnit);
+
+const OntarioMetaCovidCase = require('./src/routes/OntarioMetaCovidCase')
+app.use("/OntarioMetaCovidCase", OntarioMetaCovidCase);
 
 const PORT = process.env.PORT || 3000;
 

--- a/src/controller/OntarioMetaCovidCase.js
+++ b/src/controller/OntarioMetaCovidCase.js
@@ -1,0 +1,33 @@
+const mongoose = require("mongoose");
+const OntarioMetaCovidCase = require("../models/OntarioMetaCovidCase")
+
+exports.ontarioMetaCovidCase_get = (req, res) => {
+    OntarioMetaCovidCase.find()
+        .then(entries => {
+            const response = {
+                count: entries.length,
+                result: entries.map(entry => {
+                    return {
+                        Province: entry.Province,
+                        Total: entry.Total,
+                        Recovered: entry.Recovered,
+                        NotResolved: entry.NotResolved,
+                        Fatal: entry.Fatal,
+                    };
+                })
+            };
+            if (entries.length >= 0) {
+                res.status(200).json(response);
+            } else {
+                res.status(404).json({
+                    message: 'No Ontario meta covid case information found'
+                });
+            }
+        })
+        .catch(err => {
+            console.log(err);
+            res.status(500).json({
+                error: err
+            });
+        });
+};

--- a/src/models/OntarioMetaCovidCase.js
+++ b/src/models/OntarioMetaCovidCase.js
@@ -1,0 +1,11 @@
+const mongoose = require("mongoose");
+
+var OntarioMetaCovidCaseSchema = mongoose.Schema({
+    Province: String,
+    Total : Number,
+    Recovered: Number,
+    NotResolved: Number,
+    Fatal: Number,
+});
+
+module.exports = OntarioMetaCovidCase = mongoose.model("OntarioMetaCovidCase", OntarioMetaCovidCaseSchema)

--- a/src/routes/OntarioMetaCovidCase.js
+++ b/src/routes/OntarioMetaCovidCase.js
@@ -1,0 +1,9 @@
+//Public Health Unit
+
+const express = require('express');
+const OntarioMetaCovidCaseController = require('../controller/OntarioMetaCovidCase');
+const router = express.Router();
+
+router.get('/', OntarioMetaCovidCaseController.ontarioMetaCovidCase_get);
+  
+module.exports = router;


### PR DESCRIPTION
- Add route, controller and model for Ontario Meta covid-19
- Include endpoint paths message on direct api request